### PR TITLE
Added line to remove all subviews of the view being exploded.

### DIFF
--- a/LetterPressExplosion/LetterPressExplosion/Categories/UIView+Explode.m
+++ b/LetterPressExplosion/LetterPressExplosion/Categories/UIView+Explode.m
@@ -92,6 +92,7 @@ float randomFloat()
         [(UIImageView*)self setImage:nil];
     }
     
+    [[self subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
     [[self.layer sublayers] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
     
     for (int y = 0; y < fullRows; ++y)


### PR DESCRIPTION
This resolves the EXC_BAD_ACCESS on `removeFromSuperview` because
the subviews' backing layers were already released. Fixes lucky #13
